### PR TITLE
feat: add electron app skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "timetable-codex",
+  "version": "0.1.0",
+  "main": "src/ui/main/main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "electron": "^29.1.0"
+  }
+}

--- a/src/application/TimetableService.js
+++ b/src/application/TimetableService.js
@@ -1,0 +1,5 @@
+function sortBandsByAvailability(bands) {
+  return [...bands].sort((a, b) => a.totalAvailableSlots() - b.totalAvailableSlots());
+}
+
+module.exports = { sortBandsByAvailability };

--- a/src/data/csvBandRepository.js
+++ b/src/data/csvBandRepository.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const Band = require('../domain/Band');
+
+function parseCsv(content) {
+  const lines = content.trim().split(/\r?\n/);
+  const headers = lines.shift().split(',');
+  return lines.map((line) => {
+    const values = line.split(',');
+    const row = {};
+    headers.forEach((h, i) => {
+      row[h] = values[i];
+    });
+    return row;
+  });
+}
+
+function parseAvailability(row) {
+  const availability = {};
+  Object.keys(row).forEach((key) => {
+    const match = key.match(/^d(\d+)_h(\d+)$/);
+    if (match) {
+      const day = parseInt(match[1], 10);
+      const hour = parseInt(match[2], 10);
+      if (!availability[day]) availability[day] = {};
+      const value = String(row[key]).toLowerCase();
+      availability[day][hour] = value === 'yes' || value === '1' || value === 'true';
+    }
+  });
+  return availability;
+}
+
+function loadBandsFromCsv(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const records = parseCsv(content);
+  return records.map((row) => {
+    const name = row.Band || row.band || row.name;
+    const duration = parseInt(row.Duration || row.duration, 10);
+    const availability = parseAvailability(row);
+    return new Band(name, duration, availability);
+  });
+}
+
+module.exports = { loadBandsFromCsv };

--- a/src/domain/Band.js
+++ b/src/domain/Band.js
@@ -1,0 +1,19 @@
+class Band {
+  constructor(name, duration, availability = {}) {
+    this.name = name;
+    this.duration = duration;
+    this.availability = availability;
+  }
+
+  totalAvailableSlots() {
+    let count = 0;
+    for (const day of Object.values(this.availability)) {
+      for (const available of Object.values(day)) {
+        if (available) count += 1;
+      }
+    }
+    return count;
+  }
+}
+
+module.exports = Band;

--- a/src/ui/main/main.js
+++ b/src/ui/main/main.js
@@ -1,0 +1,64 @@
+const { app, BrowserWindow, Menu, dialog } = require('electron');
+const path = require('path');
+const { loadBandsFromCsv } = require('../../data/csvBandRepository');
+const { sortBandsByAvailability } = require('../../application/TimetableService');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile(path.join(__dirname, '../renderer/index.html'));
+  return win;
+}
+
+app.whenReady().then(() => {
+  const win = createWindow();
+
+  const template = [
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'New',
+          click: async () => {
+            const result = await dialog.showOpenDialog(win, {
+              properties: ['openFile'],
+              filters: [{ name: 'CSV', extensions: ['csv'] }]
+            });
+            if (!result.canceled && result.filePaths.length > 0) {
+              const bands = loadBandsFromCsv(result.filePaths[0]);
+              const sorted = sortBandsByAvailability(bands);
+              const payload = sorted.map((b) => ({
+                name: b.name,
+                duration: b.duration,
+                availability: b.availability,
+                totalAvailableSlots: b.totalAvailableSlots()
+              }));
+              win.webContents.send('bands-loaded', payload);
+            }
+          }
+        },
+        { label: 'Load', click: () => {} },
+        { label: 'Save', click: () => {} },
+        { label: 'Export', click: () => {} }
+      ]
+    }
+  ];
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/src/ui/main/preload.js
+++ b/src/ui/main/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  onBandsLoaded: (callback) => ipcRenderer.on('bands-loaded', (_event, bands) => callback(bands))
+});

--- a/src/ui/renderer/index.html
+++ b/src/ui/renderer/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Timetable Codex</title>
+  <style>
+    body { font-family: sans-serif; }
+    .band-block { border: 1px solid #ccc; padding: 4px; margin: 2px; display: inline-block; }
+  </style>
+</head>
+<body>
+  <h1>Timetable Codex</h1>
+  <div id="bands"></div>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/src/ui/renderer/renderer.js
+++ b/src/ui/renderer/renderer.js
@@ -1,0 +1,11 @@
+window.electronAPI.onBandsLoaded((bands) => {
+  const container = document.getElementById('bands');
+  container.innerHTML = '';
+  bands.sort((a, b) => a.totalAvailableSlots - b.totalAvailableSlots);
+  bands.forEach((b) => {
+    const div = document.createElement('div');
+    div.className = 'band-block';
+    div.textContent = `${b.name} (${b.duration}min)`;
+    container.appendChild(div);
+  });
+});

--- a/test/data/bands.csv
+++ b/test/data/bands.csv
@@ -1,0 +1,4 @@
+Band,Duration,d1_h10,d1_h11,d1_h12
+BandA,10,yes,no,yes
+BandB,15,yes,yes,yes
+BandC,15,no,no,no

--- a/test/data/csvBandRepository.test.js
+++ b/test/data/csvBandRepository.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const { loadBandsFromCsv } = require('../../src/data/csvBandRepository');
+
+test('loadBandsFromCsv parses bands', () => {
+  const csvPath = path.join(__dirname, 'bands.csv');
+  const bands = loadBandsFromCsv(csvPath);
+  assert.strictEqual(bands.length, 3);
+  assert.strictEqual(bands[0].name, 'BandA');
+  assert.strictEqual(bands[0].duration, 10);
+  assert.strictEqual(bands[0].availability[1][10], true);
+  assert.strictEqual(bands[0].availability[1][11], false);
+});


### PR DESCRIPTION
## Summary
- scaffold layered Electron project structure for timetable creator
- add CSV data loader, domain models, and renderer display
- include basic test for CSV parsing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f1e79c608323a7c7241a916adac8